### PR TITLE
Incoming WebHooks API call updated; link support

### DIFF
--- a/slacktee.conf
+++ b/slacktee.conf
@@ -1,13 +1,12 @@
 # ----------
-# Configuration 
-#   Set appropriate values before using this script
+# Configuration
+#   Describes the Incoming Webhook allowing you to post messages into Slack.
 #   After the configuration, copy this file to /etc or your home directory.
 #   NOTE : Please rename this file to '.slacktee', if you'd like to place this in your home directory.
 # ----------
-slack_domain=""     # Slack domain. You can find it in the URL. https:[Your slack domain].slack.com/
-token=""            # Incoming WebHooks Integration token, see token=[token] in Example URL. This is used for message posting. 
-upload_token=""     # User API Authentication token. This is used for uploading.
+webhook_url=""      # Incoming Webhooks integration URL. See https://my.slack.com/services/new/incoming-webhook
+upload_token=""     # The user's API authentication token, only used for file uploads. See https://api.slack.com/#auth
 channel=""          # Default channel to post messages. You don't have to add '#'.
 tmp_dir="/tmp"      # Temporary file is created in this directory.
 username="slacktee" # Default username to post messages.
-icon="bell"         # Default icon to post messages. You don't have to wrap it with ':'. See http://www.emoji-cheat-sheet.com.
+icon="ghost"        # Default emoji to post messages. You don't have to wrap it with ':'. See http://www.emoji-cheat-sheet.com.


### PR DESCRIPTION
The Slack API for Incoming WebHook integrations has slightly changed. I updated the config and cURL calls accordingly.
Also added support for an optional link for the (also optional) title.
