### PR TITLE
Add support for icon url's (not only default emojis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ channel=""          # Default channel to post messages. '#' is prepended, if it 
 tmp_dir="/tmp"      # Temporary file is created in this directory.
 username="slacktee" # Default username to post messages.
 icon="ghost"        # Default emoji to post messages. You don't have to wrap it with ':'. See http://www.emoji-cheat-sheet.com.
+icon_url=""         # Default emoji url to post messages.
 attachment=""       # Default color of the attachments. If an empty string is specified, the attachments are not used.
 ```
 
@@ -62,6 +63,7 @@ usage: slacktee.sh [options]
     -c, --channel channel_name        Post input values to specified channel or user.
     -u, --username user_name          This username is used for posting.
     -i, --icon emoji_name             This icon is used for posting.
+    --iconurl icon_url                This url is used as icon for posting.
     -t, --title title_string          This title is added to posts.
     -m, --message-formatting format   Switch message formatting (none|link_names|full).
                                       See https://api.slack.com/docs/formatting for more details.
@@ -92,10 +94,11 @@ To post the output of `find` command as a file, use `-f` option.
 find /var -name "foobar" | slacktee.sh -f
 ```
 
-You can specify `channel`, `username`, `icon`, `title`, and `link` too.
+You can specify `channel`, `username`, `icon`, `title`, and `link` too. Instead of emoji icon (-i), you may provide an image url (--iconurl).
 
 ```
 ls | slacktee.sh -c "general" -u "slacktee" -i "shipit" -t "ls" -l "http://en.wikipedia.org/wiki/Ls"
+ls | slacktee.sh -c "general" -u "slacktee" --iconurl "http://mirrors.creativecommons.org/presskit/icons/cc.png" -t "ls" -l "http://en.wikipedia.org/wiki/Ls"
 ```
 
 Of course, you can connect another command with pipe.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ usage: slacktee.sh [options]
     -l, --link                        Add a URL link to the message.
     -c, --channel channel_name        Post input values to specified channel or user.
     -u, --username user_name          This username is used for posting.
-    -i, --icon emoji_name             This icon is used for posting.
-    --iconurl icon_url                This url is used as icon for posting.
+    -i, --icon emoji_name|url         This icon is used for posting. You can use a word
+                                      from http://www.emoji-cheat-sheet.com or a direct url to an image.
     -t, --title title_string          This title is added to posts.
     -m, --message-formatting format   Switch message formatting (none|link_names|full).
                                       See https://api.slack.com/docs/formatting for more details.
@@ -94,11 +94,11 @@ To post the output of `find` command as a file, use `-f` option.
 find /var -name "foobar" | slacktee.sh -f
 ```
 
-You can specify `channel`, `username`, `icon`, `title`, and `link` too. Instead of emoji icon (-i), you may provide an image url (--iconurl).
+You can specify `channel`, `username`, `icon`, `title`, and `link` too. Instead of emoji icon, you may provide an image url.
 
 ```
 ls | slacktee.sh -c "general" -u "slacktee" -i "shipit" -t "ls" -l "http://en.wikipedia.org/wiki/Ls"
-ls | slacktee.sh -c "general" -u "slacktee" --iconurl "http://mirrors.creativecommons.org/presskit/icons/cc.png" -t "ls" -l "http://en.wikipedia.org/wiki/Ls"
+ls | slacktee.sh -c "general" -u "slacktee" -i "http://mirrors.creativecommons.org/presskit/icons/cc.png" -t "ls" -l "http://en.wikipedia.org/wiki/Ls"
 ```
 
 Of course, you can connect another command with pipe.

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -338,6 +338,11 @@ elif [[ ( "$channel" != "#"* ) && ( "$channel" != "@"* ) ]]; then
     channel="#$channel"
 fi
 
+if [[ -n "$icon" ]]; then
+	icon=${icon#:} # remove leading ':'
+	icon=${icon%:} # remove trailing ':'
+fi
+
 # ----------
 # Start script
 # ----------

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -9,6 +9,7 @@ channel="general"    # Default channel to post messages. '#' is prepended, if it
 tmp_dir="/tmp"       # Temporary file is created in this directory.
 username="slacktee"  # Default username to post messages.
 icon="ghost"         # Default emoji to post messages. Don't wrap it with ':'. See http://www.emoji-cheat-sheet.com.
+icon_url=""          # Default emoji url to post messages.
 attachment=""        # Default color of the attachments. If an empty string is specified, the attachments are not used.
 
 # ----------
@@ -50,6 +51,7 @@ function show_help(){
     echo "    -c, --channel channel_name        Post input values to specified channel or user."
     echo "    -u, --username user_name          This username is used for posting."
     echo "    -i, --icon emoji_name             This icon is used for posting."
+    echo "    --iconurl icon_url                This url is used as icon for posting."
     echo "    -t, --title title_string          This title is added to posts."
     echo "    -m, --message-formatting format   Switch message formatting (none|link_names|full)."
     echo "                                      See https://api.slack.com/docs/formatting for more details."
@@ -98,7 +100,7 @@ function send_message(){
 	    message_attr="\"text\": \"$escaped_message\","	    
 	fi
 
-        json="{\"channel\": \"$channel\", \"username\": \"$username\", $message_attr \"icon_emoji\": \":$icon:\" $parseMode}"
+        json="{\"channel\": \"$channel\", \"username\": \"$username\", $message_attr \"icon_emoji\": \":$icon:\", \"icon_url\": \"$icon_url\" $parseMode}"
         post_result=$(curl -X POST --data-urlencode "payload=$json" "$webhook_url" 2> /dev/null)
 	exit_code=1
         if [[ $post_result == "ok" ]]; then
@@ -216,6 +218,10 @@ while [[ $# -gt 0 ]]; do
             ;;
     -i|--icon)
             icon="$1"
+            shift
+            ;;
+    --iconurl)
+            icon_url="$1"
             shift
             ;;
     -t|--title)

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -8,8 +8,7 @@ upload_token=""      # The user's API authentication token, only used for file u
 channel="general"    # Default channel to post messages. '#' is prepended, if it doesn't start with '#' or '@'.
 tmp_dir="/tmp"       # Temporary file is created in this directory.
 username="slacktee"  # Default username to post messages.
-icon="ghost"         # Default emoji to post messages. Don't wrap it with ':'. See http://www.emoji-cheat-sheet.com.
-icon_url=""          # Default emoji url to post messages.
+icon="ghost"         # Default emoji to post messages. Don't wrap it with ':'. See http://www.emoji-cheat-sheet.com; can be a url too.
 attachment=""        # Default color of the attachments. If an empty string is specified, the attachments are not used.
 
 # ----------
@@ -100,7 +99,15 @@ function send_message(){
 	    message_attr="\"text\": \"$escaped_message\","	    
 	fi
 
-        json="{\"channel\": \"$channel\", \"username\": \"$username\", $message_attr \"icon_emoji\": \":$icon:\", \"icon_url\": \"$icon_url\" $parseMode}"
+	icon_url=""
+	icon_emoji=""
+	if echo "$icon" | grep -q "^https\?://.*"; then
+		icon_url="$icon"
+	else
+		icon_emoji=":$icon:"
+	fi
+
+        json="{\"channel\": \"$channel\", \"username\": \"$username\", $message_attr \"icon_emoji\": \"$icon_emoji\", \"icon_url\": \"$icon_url\" $parseMode}"
         post_result=$(curl -X POST --data-urlencode "payload=$json" "$webhook_url" 2> /dev/null)
 	exit_code=1
         if [[ $post_result == "ok" ]]; then
@@ -217,14 +224,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
     -i|--icon)
-            case "$1" in
-              http://*|https://*)
-                icon_url="$1"
-                ;;
-              *)
-                icon="$1"
-                ;;
-            esac
+            icon="$1"
             shift
             ;;
     -t|--title)

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -50,8 +50,8 @@ function show_help(){
     echo "    -l, --link                        Add a URL link to the message."
     echo "    -c, --channel channel_name        Post input values to specified channel or user."
     echo "    -u, --username user_name          This username is used for posting."
-    echo "    -i, --icon emoji_name             This icon is used for posting."
-    echo "    --iconurl icon_url                This url is used as icon for posting."
+    echo "    -i, --icon emoji_name|url         This icon is used for posting. You can use a word"
+    echo "                                      from http://www.emoji-cheat-sheet.com or a direct url to an image."
     echo "    -t, --title title_string          This title is added to posts."
     echo "    -m, --message-formatting format   Switch message formatting (none|link_names|full)."
     echo "                                      See https://api.slack.com/docs/formatting for more details."
@@ -217,11 +217,14 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
     -i|--icon)
-            icon="$1"
-            shift
-            ;;
-    --iconurl)
-            icon_url="$1"
+            case "$1" in
+              http://*|https://*)
+                icon_url="$1"
+                ;;
+              *)
+                icon="$1"
+                ;;
+            esac
             shift
             ;;
     -t|--title)


### PR DESCRIPTION
Example usage:

```
echo "testing iconurl" | ./slacktee.sh -u $HOSTNAME -p \
        --iconurl "http://global.download.synology.com/download/pkg_img/Docker/1.6.2-0036/thumb_256.png"
```

Update the README to reflect changes