### PR TITLE
Preserve leading whitespace.

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -120,8 +120,8 @@ function send_message()
 
 function process_line()
 {
-	echo "$1"
-	line="$(echo "$1" | sed $'s/\t/  /g')"
+	printf "%s\n" "$1"
+	line="$(printf "%s\n" "$1" | sed $'s/\t/  /g')"
 	if [[ $mode == "no-buffering" ]]; then
 		prefix=''
 		if [[ -z $attachment ]]; then
@@ -129,7 +129,7 @@ function process_line()
 		fi  
 		send_message "$prefix$line"
 	elif [[ $mode == "file" ]]; then
-		echo "$line" >> "$filename"
+		printf "%s" "$line" >> "$filename"
 	else
 		if [[ -z "$text" ]]; then
 			text="$line"


### PR DESCRIPTION
Previously, leading whitespace was being lopped off. Using printf preserves that whitespace.

(I first noticed the issue when trying to tee output containing Python stack traces; if you'd like similar output for testing, use something like `python -c "import foo"`: the second line should be indented relative to the rest of the output.)