### PR TITLE
fixes conditional prefix constantly being added to the title

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -93,6 +93,7 @@ function send_message()
 			message_attr="\"attachments\": [{ \"color\": \"$message_color\", \"mrkdwn_in\": [\"text\", \"fields\"], \"text\": \"$escaped_message\" "
 
 			if [[ -n $found_pattern_prefix ]]; then
+				orig_title=$title
 				title="$found_pattern_prefix $title"
 				# Clear conditional prefix for the nest send
 				found_pattern_prefix=""
@@ -100,6 +101,8 @@ function send_message()
 
 			if [[ -n $title ]]; then
 				message_attr="$message_attr, \"title\": \"$title\" "
+				# Clear conditional prefix from title
+				title=$orig_title
 			fi
 
 			if [[ -n $link ]]; then


### PR DESCRIPTION
When using a conditional prefix it would be added to the title every time the condition was met. However, because it saves the new prefixed title into the same title variable the title would grow and grow with repeated prefixes. This pull request saves the original title before adding the prefix and then resets the title to the original after it has been added to the message.