### PR TITLE
Add params to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bash ./slacktee/install.sh
 
 install.sh copies slacktee.sh in `/usr/local/bin` and sets executable permission. 
 
-If you'd like to install it in the different directory such as `/usr/bin`, pass the target directory as a parameter of install.sh. 
+If you'd like to install it in the different directory such as `/usr/bin`, pass the target directory as a parameter of install.sh. For a detailled information about how to configue the path or the name please check `./install.sh --help`
 By default, `/usr/local/bin` may not be included in your `$PATH` environment variable (you should be aware of this when you use *slacktee* in *crontab*). So, if you would like to use *slacktee* without specifying its full path, coping it to `/usr/bin` may be a good idea.
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,44 @@
 #!/usr/bin/env bash
 
+show_help () {
+	cat <<-HELP
+	usage: ${0##*/} [options] [path]
+	  options:
+	    -h, --help        Show this help
+	    -n, --name value  Use value for the command name (eg. slacktee)
+	    -p, --path value  Use value for the path (eg. /usr/bin/)
+	  path:
+	    optionally you can pass directy the path without the argument -p,--path
+	HELP
+	exit
+}
+
+# defaults
 install_path=/usr/local/bin
 slacktee_script="slacktee.sh"
 
-if [ $# -ne 0 ]; then
-    install_path=$1
-fi
+# parse the arguments of the script
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-h|--help)
+			show_help
+			;;
+		-n|--name)
+			([ "${2##-*}" != "" ] && slacktee_script="$2" && shift) ||
+				(echo -e 'name value not expecified\n' && show_help)
+			;;
+		-p|--path)
+			([ "${2##-*}" != "" ] && install_path="$2" && shift) ||
+				(echo -e 'path value not expecified\n' && show_help)
+			;;
+		*)
+			# backwards compatibility
+			[ "${1##-*}" != "" ] && install_path="$1"
+			;;
+	esac
+	shift
+done
+
 script_dir=$( cd $(dirname $0); pwd -P )
 
 # Copy slacktee.sh to /usr/local/bin 


### PR DESCRIPTION
I've try to use the same style, except 2 minor things. show_help here documents and parameter expansion in the value check (both used to reduce the number of subprocess used)

Refences I've used (just in case)
http://tldp.org/LDP/abs/html/here-docs.html (search for `<<-`)
http://wiki.bash-hackers.org/syntax/pe#substring_removal

kudos!

(closes #30)
