### PR TITLE
Check the existence of curl command

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -570,6 +570,10 @@ function setup_environment()
 # ----------
 function check_configuration() 
 {
+	if [[ -z $(command -v curl) ]]; then
+		err_exit 1 "curl is not installed. Please install it first."
+	fi
+
 	if [[ $webhook_url == "" ]]; then
 		err_exit 1 "Please setup the webhook url of this incoming webhook integration."
 	fi

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -46,7 +46,7 @@ function err_exit()
 {
 	exit_code=$1
 	shift
-	echo "$@" > /dev/null >&2
+	echo "$me: $@" > /dev/null >&2
 	exit $exit_code
 }
 


### PR DESCRIPTION
If 'curl' command is not installed, slacktee fails to send the message to Slack and dies silently (Issue #35).
In order to avoid this issue, this change checks the existence of 'curl' command in `check_configuration` and displays an error message.