### PR TITLE
Add a way to change the script name during the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ By default, `/usr/local/bin` may not be included in your `$PATH` environment var
 # Install slacktee.sh in /usr/bin
 bash ./slacktee/install.sh /usr/bin
 ```
+
+Also, you can rename slacktee.sh during the installation. If you would like to give a different name to slacktee.sh, simply append it to the target directory.
+
+```
+# Install slacktee.sh in /usr/local/bin as 'slacktee'
+bash ./slacktee/install.sh /usr/local/bin/slacktee
+```
+
 After the installation, interactive setup starts automatically.
 
 Configuration

--- a/install.sh
+++ b/install.sh
@@ -3,18 +3,31 @@
 install_path=/usr/local/bin
 slacktee_script="slacktee.sh"
 
-if [ $# -ne 0 ]; then
+if [[ $# -ne 0 ]]; then
     install_path=$1
 fi
 script_dir=$( cd $(dirname $0); pwd -P )
 
 # Copy slacktee.sh to /usr/local/bin 
-cp "$script_dir/$slacktee_script" "$install_path"
+cp -i "$script_dir/$slacktee_script" "$install_path"
+if [[ $? -ne 0 ]]; then
+	exit 1
+fi
+
+message="$slacktee_script has been installed to $install_path"
+
+if [[ -f "$install_path" ]]; then
+    # Looks like the new file name is specified with the target directory
+    original_name=$slacktee_script
+    slacktee_script=$(basename "$install_path")
+    install_path=$(dirname "$install_path")
+    message="$original_name has been installed to $install_path as $slacktee_script"
+fi
 
 # Set execute permission
 chmod +x "$install_path/$slacktee_script"
 
-echo "$slacktee_script has been installed to $install_path"
+echo $message
 
 # Execute slacktee.sh with --setup option
 "$install_path/$slacktee_script" --setup


### PR DESCRIPTION
In order to address the request adding a way to change the script name during the installation (Issue #30), I updated install.sh. If the new file name is appended to the target directory, install.sh installs `slacktee.sh` as the specified file name.
```
# Install slacktee.sh in /usr/local/bin as 'slacktee'
bash install.sh /usr/local/bin/slacktee
```
