### PR TITLE
Enforce character limits as described in the Slack Realtime Messaging API docs

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -250,7 +250,14 @@ function process_line()
 		if [[ -z "$text" ]]; then
 			text="$line"
 		else
-			text="$text\n$line"
+			# See https://api.slack.com/rtm#limits for details on character limits
+			local message="$text\n$line"
+			if [[ ${#message} -ge 4000 ]]; then
+				send_message "$text"
+				text="$line"
+			else
+				text="$text\n$line"
+			fi
 		fi  
 	fi  
 }


### PR DESCRIPTION
If a message exceed the limits then Slack outputs it as two separate messages which breaks the code block formatting and results in the message being displayed as plain text (including the ``` text wrappers).

This update checks if the new line of content will push the message over the Slack limit. If so it sends the existing message content and adds the line to a fresh message.

See https://api.slack.com/rtm#limits for details regarding the limits.